### PR TITLE
fix links to R Dev Day issues

### DIFF
--- a/cronograma/r-dev-day/index.qmd
+++ b/cronograma/r-dev-day/index.qmd
@@ -50,7 +50,7 @@ Los grupos pequeños pueden acordar un idioma común para trabajar - el inglés 
 
 ## Tareas
 
-Las tareas se prepararán como [issues en este repositorio con la etiqueta `LatinR2024`](https://github.com/r-devel/r-dev-day/issues?q=is%3Aissue+is%3Aopen+label%3ALatinR2024). Te invitamos a añadir temas o discutir ideas para temas como se describe en el [README](https://github.com/r-devel/r-dev-day/blob/main/README.md).
+Las tareas se prepararán como [issues en este repositorio con la etiqueta `LatinR2024`](https://github.com/r-devel/r-dev-day/issues?q=is%3Aissue+is%3Aopen+label%3A"LatinR+2024"). Te invitamos a añadir temas o discutir ideas para temas como se describe en el [README](https://github.com/r-devel/r-dev-day/blob/main/README.md).
 
 Los issues están resumidos en la hoja de Google [R Dev Day \@ LatinR 2024 Working Group Allocations](https://docs.google.com/spreadsheets/d/1Nuwusm7Xgwpw54KZnnrnNVT9vPkOk2qmromBEbYNHnU/edit). Añade tu nombre a la lista de colaboradores si estás interesado en trabajar en un tema. Puedes agregarte a múltiples temas ya que no es un compromiso final - las asignaciones se finalizarán al comienzo de cada sesión.
 

--- a/cronograma/r-dev-day/rdevday-en.qmd
+++ b/cronograma/r-dev-day/rdevday-en.qmd
@@ -53,7 +53,7 @@ Small groups can agree on a common language to work in - English will be the def
 
 ## Tasks
 
-Tasks will be prepared as [issues on this repository with label `LatinR2024`](https://github.com/r-devel/r-dev-day/issues?q=is%3Aissue+is%3Aopen+label%3ALatinR2024).
+Tasks will be prepared as [issues on this repository with label `LatinR2024`](https://github.com/r-devel/r-dev-day/issues?q=is%3Aissue+is%3Aopen+label%3A"LatinR+2024").
 You are welcome to add issues or discuss ideas for issues as described in the [README](https://github.com/r-devel/r-dev-day/blob/main/README.md).
 
 The issues are summarised in the Google Sheet [R Dev Day \@ LatinR 2024 Working Group Allocations](https://docs.google.com/spreadsheets/d/1Nuwusm7Xgwpw54KZnnrnNVT9vPkOk2qmromBEbYNHnU/edit).

--- a/cronograma/r-dev-day/rdevday-pt.qmd
+++ b/cronograma/r-dev-day/rdevday-pt.qmd
@@ -53,7 +53,7 @@ Os grupos menores podem acordar um idioma comum para trabalhar - o inglês será
 
 ## Tarefas
 
-As tarefas serão preparadas como [*issues* neste repositório com o rótulo `LatinR2024`](https://github.com/r-devel/r-dev-day/issues?q=is%3Aissue+is%3Aopen+label%3ALatinR2024). Você pode adicionar *issues* ou discutir ideias para *issues*, conforme descrito no [README](https://github.com/r-devel/r-dev-day/blob/main/README.md).
+As tarefas serão preparadas como [*issues* neste repositório com o rótulo `LatinR2024`](https://github.com/r-devel/r-dev-day/issues?q=is%3Aissue+is%3Aopen+label%3A"LatinR+2024"). Você pode adicionar *issues* ou discutir ideias para *issues*, conforme descrito no [README](https://github.com/r-devel/r-dev-day/blob/main/README.md).
 
 As *issues* estão resumidos na planilha do [R Dev Day \@ LatinR 2024 Working Group Allocations](https://docs.google.com/spreadsheets/d/1Nuwusm7Xgwpw54KZnnrnNVT9vPkOk2qmromBEbYNHnU/edit). Adicione seu nome à lista de pessoas colaboradoras se tiver interesse em trabalhar em uma *issue*. Você pode se incluir em várias *issues*, pois não se trata de um compromisso final - as alocações serão finalizadas no início de cada sessão.
 


### PR DESCRIPTION
Correcting links as reported here: https://github.com/r-devel/r-dev-day/issues/82